### PR TITLE
Command line version

### DIFF
--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -98,121 +98,23 @@ namespace Titanfall2_SkinTool
 
         private void Test_Click(object sender, EventArgs e)
         {
-            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            String msg;
             try
             {
-                if (File.Exists(GamePath + "\\r5apex.exe") || File.Exists(GamePath + "\\Titanfall2.exe"))
-                {
-                    //fixed
-                }
-                else
-                {
-                    throw new MyException(rm.GetString("GameLoadFailed"));
-                }
-                if (!File.Exists(PathText.Text) || PathText.Text == "")
-                {
-                    throw new MyException(rm.GetString("ZipLoadFailed"));
-                }
+                SkinTool tool = new SkinTool(GamePath, SelectedGame, (m) => textBox1.AppendText(m + "\r\n"));
+                tool.InstallSkin(PathText.Text);
 
-                string ExtractPath = filePath + "\\" + rm.GetString("SaveFolder") + "\\" + Folder;
-                if (!Directory.Exists(ExtractPath))
-                {
-                    Directory.CreateDirectory(ExtractPath);
-                }
-                try
-                {
-                    ZipFile.ExtractToDirectory(PathText.Text, ExtractPath, Encoding.GetEncoding("GBK"));
-                    textBox1.AppendText(rm.GetString("ZipLoadSuccess") + "\r\n");
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show(ex.Message);
-                }
-
-                //Testing new way to save dds
-                List<string> FileList = new List<string>();
-                FindSkinFiles(ExtractPath, FileList, ".dds");
-
-                foreach (var i in FileList)
-                    Console.WriteLine(i);
-
-                DDSFolderExist = FileList.Count;
-                if (DDSFolderExist == 0)
-                {
-                    throw new MyException(rm.GetString("FindSkinFailed"));
-                }
-
-                foreach (var i in FileList)
-                {
-                    int FolderLength = ExtractPath.Length;
-                    String FileString = i.Substring(FolderLength);
-                    int imagecheck = ImageCheck(i);
-                    //the following code is waiting for the custom model
-                    Int64 toseek = 0;
-                    int tolength = 0;
-                    int totype = 0;
-                    //传递数组内容
-                    //需要使用命名对代码进行优化
-                    if (IsPilot(i))
-                    {
-                        Titanfall2.PilotData.PilotDataControl pdc = new Titanfall2.PilotData.PilotDataControl(i, imagecheck);
-                        toseek = Convert.ToInt64(pdc.Seek);
-                        tolength = Convert.ToInt32(pdc.Length);
-                        totype = Convert.ToInt32(pdc.SeekLength);
-                    }
-                    else //if(IsWeapon(i))
-                    {
-                        if (SelectedGame == "APEX")
-                        {
-                            APEX.WeaponData.WeaponDataControl wdc = new APEX.WeaponData.WeaponDataControl(i, imagecheck);
-                            toseek = Convert.ToInt64(wdc.FilePath[0, 1]);
-                            tolength = Convert.ToInt32(wdc.FilePath[0, 2]);
-                            totype = Convert.ToInt32(wdc.FilePath[0, 3]);
-                        }
-                        else if (SelectedGame == "Titanfall2")
-                        {
-                            Titanfall2.WeaponData.WeaponDataControl wdc = new Titanfall2.WeaponData.WeaponDataControl(i, imagecheck);
-                            toseek = Convert.ToInt64(wdc.FilePath[0, 1]);
-                            tolength = Convert.ToInt32(wdc.FilePath[0, 2]);
-                            totype = Convert.ToInt32(wdc.FilePath[0, 3]);
-                        }
-                    }
-                    StarpakControl sc = new StarpakControl(i, toseek, tolength, totype, GamePath, SelectedGame, imagecheck, "Replace");
-                    //ToDo:Change to the Struct,still not done that...
-                }
-
-                FileList.Clear();
-                msg = rm.GetString("InstallSuccess");
-                textBox1.AppendText(msg + "\r\n");
-                MessageBox.Show(msg, rm.GetString("Tip"), MessageBoxButtons.OK);
+                // success
+                msg = "Install succes!";
             }
-            catch (MyException myException)
+            catch (Exception ex)   // Catches MyException as well
             {
-                MessageBox.Show(myException.Message);
+                // failed
+                msg = "Install failed: " + ex.Message;
             }
-            catch (Exception ex)
-            {
-                MessageBox.Show(ex.Message);
-            }
-            GC.Collect();
-            if (Directory.Exists(rm.GetString("SaveFolder")))
-            {
-                try
-                {
-                    DirectoryInfo tempDir = new DirectoryInfo(rm.GetString("SaveFolder"));
 
-                    foreach (DirectoryInfo dir in tempDir.EnumerateDirectories())
-                    {
-                        dir.Delete(true);
-                    }
-
-                    tempDir.Delete();
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show("Error occured while trying to delete the temporary files folder: \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
-            }
+            // info popup
+            MessageBox.Show(msg, rm.GetString("Tip"), MessageBoxButtons.OK);
         }
 
         private void Language_Default()
@@ -423,86 +325,6 @@ namespace Titanfall2_SkinTool
         {
             SkinPackMakerWindow window = new SkinPackMakerWindow(SelectedGame);
             window.ShowDialog();
-        }
-
-        private void FindSkinFiles(string FolderPath, List<string> FileList, string FileExtention)
-        {
-            try
-            {
-                DirectoryInfo di = new DirectoryInfo(FolderPath);
-                FileSystemInfo[] fi = di.GetFileSystemInfos();
-                foreach (var i in fi)
-                {
-                    if (i is DirectoryInfo)
-                    {
-                        FindSkinFiles(i.FullName, FileList, FileExtention);
-                    }
-                    else
-                    {
-                        if (i.Extension == FileExtention)
-                        {
-                            FileList.Add(i.FullName);
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(ex.Message);
-            }
-        }
-
-        private int ImageCheck(String ImageName)
-        {
-            int result = -1;
-            int temp = ImageName.LastIndexOf("\\");
-            ImageName = ImageName.Substring(0, temp);
-            temp = ImageName.LastIndexOf("\\") + 1;
-            ImageName = ImageName.Substring(temp, ImageName.Length - temp);
-            switch (ImageName)
-            {
-                case "256x128":
-                case "256x256":
-                case "256":
-                    //Big change,I don't want to do it:(
-                    break;
-                case "512x256":
-                case "512x512":
-                case "512":
-                    result = 0;
-                    break;
-                case "1024x512":
-                case "1024x1024":
-                case "1024":
-                    result = 1;
-                    break;
-                case "2048x1024":
-                case "2048x2048":
-                case "2048":
-                    result = 2;
-                    break;
-                case "4096x2048":
-                case "4096x4096":
-                case "4096":
-                    result = 3;
-                    break;
-                default:
-                    result = -1;
-                    break;
-            }
-            return result;
-        }
-
-        private bool IsPilot(string Name)
-        {
-            if (Name.Contains("Stim_") || Name.Contains("PhaseShift_") || Name.Contains("HoloPilot_") || Name.Contains("PulseBlade_") || Name.Contains("Grapple_") || Name.Contains("AWall_") || Name.Contains("Cloak_") || Name.Contains("Public_"))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
         }
 
         private void MainWindow_OnShown(object sender, EventArgs e)

--- a/Program.cs
+++ b/Program.cs
@@ -62,9 +62,10 @@ namespace Titanfall2_SkinTool
                     wait = o.Wait;
                     Action<string> messageHandler = o.Verbose ? m => { Console.WriteLine(m); } : m => { };
 
-                    messageHandler($"GamePath={o.GamePath}");
-                    messageHandler($"InputFiles=[{string.Join(", ", o.InputFiles)}]");
-                    messageHandler($"Verbos={o.Verbose}");
+                    // debug: print args
+                    // messageHandler($"GamePath={o.GamePath}");
+                    // messageHandler($"InputFiles=[{string.Join(", ", o.InputFiles)}]");
+                    // messageHandler($"Verbos={o.Verbose}");
 
                     try
                     {
@@ -73,7 +74,6 @@ namespace Titanfall2_SkinTool
                         foreach (string file in o.InputFiles)
                         {
                             messageHandler(Path.GetFileNameWithoutExtension(file));
-
                             tool.InstallSkin(file);
                         }
                     }
@@ -86,7 +86,7 @@ namespace Titanfall2_SkinTool
                 }).WithNotParsed(_ =>
                 {
                     // argument parsing failed -> print error
-                    Console.Error.WriteLine($"Parsing options failed. See above for more information or use --help to get help.");
+                    Console.Error.WriteLine($"Parsing options failed. See above for more information on how to use.");
                     wait = true; // let user see error
                 });
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,19 +1,104 @@
 ﻿using System;
+using System.IO;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
 using System.Windows.Forms;
+using CommandLine;
+using System.Runtime.InteropServices;
 
 namespace Titanfall2_SkinTool
 {
+    public class Options
+    {
+        [Value(0, HelpText = "Path/To/Game/Directory", Required = true)]
+        public string GamePath { get; set; }
+
+
+        [Value(1, HelpText = "List of <path/to/skin.zip> to install.", Required = true)]
+        public IEnumerable<string> InputFiles { get; set; }
+
+        [Option('v', "verbose", Required = false, HelpText = "Enable verbose logging")]
+        public bool Verbose { get; set; }
+
+        [Option('w', "wait", Required = false, HelpText = "Wait for user input before closing console window")]
+        public bool Wait { get; set; }
+    }
+
     static class Program
     {
+        /// <summary>
+        /// Used to display console if used with commandline arguments
+        /// </summary>
+        /// <returns></returns>
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        static extern bool AllocConsole();
+
         /// <summary>
         /// 应用程序的主入口点。
         /// </summary>
         [STAThread]
-        static void Main()
+        static void Main(string[] args)
+        {
+            if (0 < args.Length)
+            {
+                // args -> is commandline
+                CommandlineMain(args);
+            }
+            else
+            {
+                // no args -> default windowed application
+                UiMain();
+            }
+        }
+
+        static void CommandlineMain(string[] args)
+        {
+            bool wait = false;
+            AllocConsole();
+
+            CommandLine.Parser.Default.ParseArguments<Options>(args)
+                .WithParsed(o =>
+                {
+                    wait = o.Wait;
+                    Action<string> messageHandler = o.Verbose ? m => { Console.WriteLine(m); } : m => { };
+
+                    messageHandler($"GamePath={o.GamePath}");
+                    messageHandler($"InputFiles=[{string.Join(", ", o.InputFiles)}]");
+                    messageHandler($"Verbos={o.Verbose}");
+
+                    try
+                    {
+                        SkinTool tool = new SkinTool(o.GamePath, messageHandler);
+
+                        foreach (string file in o.InputFiles)
+                        {
+                            messageHandler(Path.GetFileNameWithoutExtension(file));
+
+                            tool.InstallSkin(file);
+                        }
+                    }
+                    catch (Exception ex)   // Catches MyException as well
+                    {
+                        Console.Error.WriteLine(ex.ToString());
+                        wait = true; // let user see error
+                    }
+
+                }).WithNotParsed(_ =>
+                {
+                    // argument parsing failed -> print error
+                    Console.Error.WriteLine($"Parsing options failed. See above for more information or use --help to get help.");
+                    wait = true; // let user see error
+                });
+
+            // maybe wait for user input before closing
+            if (wait)
+            {
+                Console.Write("Press any key to exit...");
+                Console.Read();
+            }
+        }
+
+        static void UiMain()
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/SkinTool.cs
+++ b/SkinTool.cs
@@ -62,6 +62,7 @@ namespace Titanfall2_SkinTool
 
         public void InstallSkin(string skinPath)
         {
+            messageHandler($"Install skin {skinPath}");
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             try
             {

--- a/SkinTool.cs
+++ b/SkinTool.cs
@@ -62,7 +62,9 @@ namespace Titanfall2_SkinTool
 
         public void InstallSkin(string skinPath)
         {
-            messageHandler($"Install skin {skinPath}");
+            Exception error = null;
+
+            messageHandler($"Install skin {Path.GetFileNameWithoutExtension(skinPath)}");
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             try
             {
@@ -168,10 +170,15 @@ namespace Titanfall2_SkinTool
                     }
                     catch (Exception ex)
                     {
-                        // redirect
-                        throw new MyException("Error occured while trying to delete the temporary files folder: \n" + ex.Message);
+                        // rethrow; also dont throw from finally directly (at least thats what vs says)
+                        error = new MyException("Error occured while trying to delete the temporary files folder: \n" + ex.Message);
                     }
                 }
+            }
+
+            if (error != null)
+            {
+                throw error;
             }
         }
 

--- a/SkinTool.cs
+++ b/SkinTool.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+using System.Resources;
+using System.Text;
+
+/// <summary>
+/// Basically pulled all the needed functions from MainWindow.cs
+/// into here to be able to install skins w/o the user inteface
+/// </summary>
+namespace Titanfall2_SkinTool
+{
+
+    public interface IMessageSink
+    {
+        public void Process(string message);
+    }
+
+    public class SkinTool
+    {
+        private String gamePath;
+        private String selectedGame;
+        private Action<string> messageHandler;
+        private ResourceManager rm = new ResourceManager("Titanfall2_SkinTool.Language", Assembly.GetExecutingAssembly());
+
+        /// <summary>
+        ///  For use with commandline
+        /// </summary>
+        /// <param name="gamePath"></param>
+        /// <param name="messageHandler"></param>
+        public SkinTool(string gamePath, Action<string> messageHandler)
+        {
+            this.messageHandler = messageHandler;
+            this.gamePath = System.IO.Path.GetDirectoryName(gamePath);
+            switch (System.IO.Path.GetFileName(gamePath))
+            {
+                case "r5apex.exe":
+                    selectedGame = "APEX";
+                    break;
+                case "Titanfall2.exe":
+                    selectedGame = "Titanfall2";
+                    break;
+                default:
+                    throw new MyException($"Invalid game path {gamePath}");
+            }
+        }
+
+        /// <summary>
+        /// For use in MainWindow.cs
+        /// </summary>
+        /// <param name="gamePath"></param>
+        /// <param name="selectedGame"></param>
+        /// <param name="messageHandler"></param>
+        public SkinTool(string gamePath, string selectedGame, Action<string> messageHandler)
+        {
+            this.gamePath = gamePath;
+            this.selectedGame = selectedGame;
+            this.messageHandler = messageHandler;
+        }
+
+        public void InstallSkin(string skinPath)
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            try
+            {
+                if (!(File.Exists(gamePath + "\\r5apex.exe") || File.Exists(gamePath + "\\Titanfall2.exe")))
+                {
+                    throw new MyException(rm.GetString("GameLoadFailed"));
+                }
+                if (!File.Exists(skinPath))
+                {
+                    throw new MyException(rm.GetString("ZipLoadFailed"));
+                }
+
+                string ExtractPath = Environment.CurrentDirectory + "\\" + rm.GetString("SaveFolder") + "\\" + Path.GetFileNameWithoutExtension(skinPath);
+                if (!Directory.Exists(ExtractPath))
+                {
+                    Directory.CreateDirectory(ExtractPath);
+                }
+                try
+                {
+                    ZipFile.ExtractToDirectory(skinPath, ExtractPath, Encoding.GetEncoding("GBK"));
+                    messageHandler(rm.GetString("ZipLoadSuccess"));
+                }
+                catch (Exception ex)
+                {
+                    // todo: only message?
+                    // was: MessageBox.Show(ex.Message);
+                    messageHandler(ex.Message);
+                }
+
+                //Testing new way to save dds
+                List<string> FileList = new List<string>();
+                FindSkinFiles(ExtractPath, FileList, ".dds");
+
+                // ToDo: assumed those are debug logs and disabled them.
+                //       (Do mess up output when using command line version)
+                // foreach (var i in FileList)
+                //    Console.WriteLine(i);
+
+
+                int DDSFolderExist = FileList.Count;
+                if (DDSFolderExist == 0)
+                {
+                    throw new MyException(rm.GetString("FindSkinFailed"));
+                }
+
+                foreach (var i in FileList)
+                {
+                    int FolderLength = ExtractPath.Length;
+                    String FileString = i.Substring(FolderLength);
+                    int imagecheck = ImageCheck(i);
+                    //the following code is waiting for the custom model
+                    Int64 toseek = 0;
+                    int tolength = 0;
+                    int totype = 0;
+                    //传递数组内容
+                    //需要使用命名对代码进行优化
+                    if (IsPilot(i))
+                    {
+                        Titanfall2.PilotData.PilotDataControl pdc = new Titanfall2.PilotData.PilotDataControl(i, imagecheck);
+                        toseek = Convert.ToInt64(pdc.Seek);
+                        tolength = Convert.ToInt32(pdc.Length);
+                        totype = Convert.ToInt32(pdc.SeekLength);
+                    }
+                    else //if(IsWeapon(i))
+                    {
+                        if (selectedGame == "APEX")
+                        {
+                            APEX.WeaponData.WeaponDataControl wdc = new APEX.WeaponData.WeaponDataControl(i, imagecheck);
+                            toseek = Convert.ToInt64(wdc.FilePath[0, 1]);
+                            tolength = Convert.ToInt32(wdc.FilePath[0, 2]);
+                            totype = Convert.ToInt32(wdc.FilePath[0, 3]);
+                        }
+                        else if (selectedGame == "Titanfall2")
+                        {
+                            Titanfall2.WeaponData.WeaponDataControl wdc = new Titanfall2.WeaponData.WeaponDataControl(i, imagecheck);
+                            toseek = Convert.ToInt64(wdc.FilePath[0, 1]);
+                            tolength = Convert.ToInt32(wdc.FilePath[0, 2]);
+                            totype = Convert.ToInt32(wdc.FilePath[0, 3]);
+                        }
+                    }
+                    StarpakControl sc = new StarpakControl(i, toseek, tolength, totype, gamePath, selectedGame, imagecheck, "Replace");
+                    //ToDo:Change to the Struct,still not done that...
+                }
+
+                messageHandler(rm.GetString("InstallSuccess"));
+            }
+            finally
+            {
+                // cleanup
+                GC.Collect();
+                if (Directory.Exists(rm.GetString("SaveFolder")))
+                {
+                    try
+                    {
+                        DirectoryInfo tempDir = new DirectoryInfo(rm.GetString("SaveFolder"));
+
+                        foreach (DirectoryInfo dir in tempDir.EnumerateDirectories())
+                        {
+                            dir.Delete(true);
+                        }
+
+                        tempDir.Delete();
+                    }
+                    catch (Exception ex)
+                    {
+                        // redirect
+                        throw new MyException("Error occured while trying to delete the temporary files folder: \n" + ex.Message);
+                    }
+                }
+            }
+        }
+
+        private void FindSkinFiles(string FolderPath, List<string> FileList, string FileExtention)
+        {
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(FolderPath);
+                FileSystemInfo[] fi = di.GetFileSystemInfos();
+                foreach (var i in fi)
+                {
+                    if (i is DirectoryInfo)
+                    {
+                        FindSkinFiles(i.FullName, FileList, FileExtention);
+                    }
+                    else
+                    {
+                        if (i.Extension == FileExtention)
+                        {
+                            FileList.Add(i.FullName);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // will be caught and processed in InstallSkin
+                throw new MyException(ex.Message);
+            }
+        }
+
+        private int ImageCheck(String ImageName)
+        {
+            int result = -1;
+            int temp = ImageName.LastIndexOf("\\");
+            ImageName = ImageName.Substring(0, temp);
+            temp = ImageName.LastIndexOf("\\") + 1;
+            ImageName = ImageName.Substring(temp, ImageName.Length - temp);
+            switch (ImageName)
+            {
+                case "256x128":
+                case "256x256":
+                case "256":
+                    //Big change,I don't want to do it:(
+                    break;
+                case "512x256":
+                case "512x512":
+                case "512":
+                    result = 0;
+                    break;
+                case "1024x512":
+                case "1024x1024":
+                case "1024":
+                    result = 1;
+                    break;
+                case "2048x1024":
+                case "2048x2048":
+                case "2048":
+                    result = 2;
+                    break;
+                case "4096x2048":
+                case "4096x4096":
+                case "4096":
+                    result = 3;
+                    break;
+                default:
+                    result = -1;
+                    break;
+            }
+            return result;
+        }
+
+        private bool IsPilot(string Name)
+        {
+            if (Name.Contains("Stim_") || Name.Contains("PhaseShift_") || Name.Contains("HoloPilot_") || Name.Contains("PulseBlade_") || Name.Contains("Grapple_") || Name.Contains("AWall_") || Name.Contains("Cloak_") || Name.Contains("Public_"))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Titanfall2-SkinTool.csproj
+++ b/Titanfall2-SkinTool.csproj
@@ -45,13 +45,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BCnEncoder.Net" Version="2.1.0" />
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="8.3.3" />
-    <PackageReference Include="Magick.NET.Core" Version="8.3.3" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="9.0.0" />
+    <PackageReference Include="Magick.NET.Core" Version="9.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Language.en-US.Designer.cs" />

--- a/Titanfall2-SkinTool.sln
+++ b/Titanfall2-SkinTool.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31410.223
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Titanfall2-SkinTool", "Titanfall2-SkinTool.csproj", "{0F381A90-5816-4B97-A121-BD4B08AE1E75}"
 EndProject

--- a/packages.config
+++ b/packages.config
@@ -3,4 +3,5 @@
   <package id="Magick.NET.Core" version="8.3.3" targetFramework="net45" />
   <package id="Magick.NET-Q16-AnyCPU" version="8.3.3" targetFramework="net45" />
   <package id="System.Runtime" version="4.3.1" targetFramework="net45" />
+  <package id="CommandLineParser" version="2.8.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Adds the ability to install skins from the command line without using the UI.
Arguments are: <game_path> <skin_zip_path> [<skin_zip_path>]+ [-verbose]? [-quit]?
Will install all the skin_zips to given game_path.
`--v, -verbose` (flag): Print some stuff
`--q, -quit` (flag): Close console after install is complete without waiting for user action

Simple example:
`Titanfall2-SkinTool.exe "C:\Program Files (x86)\Steam\steamapps\common\Titanfall2\Titanfall2.exe" C:\Users\whothis\Downloads\KraberSkin.zip C:\Users\whothis\Downloads\CarSkin.zip --q`
-> Installs the skins `KraberSkin.zip` and `CarSkin.zip` from `Downloads\ `to Titanfall2 (default steam install)

Changes (at least most of the significant ones):
- Use `CommandLineParser` package (https://www.nuget.org/packages/CommandLineParser)
    -> No clue if I did that right but I added it to the `package.config` and installed it via vs studio nuget
- `SkinTool.cs`: Pulled code to install a skin from `MainWindow.cs::Test_Click` (only did minor modifications to keep everything running)
- `MainWindow`: use newly pulled functions in `Test_Click`
- `Program.cs`: 
    - Modifiy main to either:
        - Show UI if no arguments were given (just as it was before)
        - Directly install skins from arguments w/o showing the UI
    - Add return codes:
        - UI always returns `0`
        - Command line returns `0 = succes, -1 = install failed, -2 = invalid arguments`

Only tested with Titanfall2, no Apex install at hand.

Mainly made this for my own use then thought I might as well leave it here in case you'd like to add it as a feature.

Notes: 
1) I'm rather new to c# so code style may vary.
2) I did some testing and everything seems fine but if you want to merge this I strongly recommend double checking what I did as most of it is educated guess-work.
3) I really hope I did not miss anything while looking around and just created some feature that is already there >.<